### PR TITLE
Update the headers by using the Cards array

### DIFF
--- a/src/components/ExploreFeatures.js
+++ b/src/components/ExploreFeatures.js
@@ -66,6 +66,10 @@ const CardItem = forwardRef((props, ref) => {
   );
 });
 
+const CardItemHeader = (props) => {
+  return <p className="headers-post">{props.header}</p>;
+};
+
 function ExploreFeatures() {
   const headerRef = useRef();
   const headerTextRef = useRef();
@@ -148,10 +152,9 @@ function ExploreFeatures() {
             {/* I didn't have the time to do it, because I was facing issues with ref.  */}
             {/* If you do this, know about forwardRef, see what I did in the cardItem function */}
             <div className="headers-post-parent" ref={headerTextRef}>
-              <p className="headers-post">Payments</p>
-              <p className="headers-post">Savings</p>
-              <p className="headers-post">Investments</p>
-              <p className="headers-post">Borrowing</p>
+              {cards.map((card, index) => (
+                <CardItemHeader key={index} header={card.header} />
+              ))}
             </div>
           </div>
         </div>

--- a/src/components/ExploreFeatures.js
+++ b/src/components/ExploreFeatures.js
@@ -147,10 +147,6 @@ function ExploreFeatures() {
         <div className="ultimate-wrapper-astendo" ref={headerRef}>
           <div className="header-articles">
             <p className="explore-articles">Explore features</p>
-
-            {/* TODO: Update Headers by using the cards array  */}
-            {/* I didn't have the time to do it, because I was facing issues with ref.  */}
-            {/* If you do this, know about forwardRef, see what I did in the cardItem function */}
             <div className="headers-post-parent" ref={headerTextRef}>
               {cards.map((card, index) => (
                 <CardItemHeader key={index} header={card.header} />

--- a/src/components/ExploreFeatures.js
+++ b/src/components/ExploreFeatures.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useLayoutEffect, forwardRef } from "react";
+import React, { useRef, useEffect, forwardRef } from "react";
 import "../styles/style.css";
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";


### PR DESCRIPTION
Fixed the minor TODO where now the headers will be updated when you update the Cards array as well.

Now the Cards can easily be updated by only updating the Cards array (on Line 9 of _ExploreFeatures.js_)

Image showing the header and cards working correctly:
![image](https://user-images.githubusercontent.com/11934220/205207944-1111e32b-7e3a-48c5-9e72-31ee729fe31a.png)

I didn't end up having to touch useRef, because that was already in the header. 